### PR TITLE
Support automatic provision with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code for managing Networked Transport of RTCM via Internet Protocol
 
 ## Features
 
- 1. Static IP for RJ45 (ethernet) network - input as manufacturing step.  `10.1.1.1/8`.
+ 1. Static IP for RJ45 (ethernet) network - input as manufacturing step.  `10.0.2.2/8`.
  2. Use a proxy to/from UART to Mavlink FMU and `udp://10.255.255.255:14550`.
 
 ## Setup

--- a/config/network.conf
+++ b/config/network.conf
@@ -1,5 +1,5 @@
 [Service]
 IFACE=eth0
-HOST=10.1.1.1
+HOST=10.0.2.2
 GATEWAY=
 NETMASK=8

--- a/meta-ntrip/README.md
+++ b/meta-ntrip/README.md
@@ -1,17 +1,28 @@
-This README file contains information on the contents of the ../sources/meta-ntrip layer.
+# ntrip/meta-ntrip
+
+This file contains information on the contents of the ../sources/meta-ntrip layer.
 
 ***IMPORTANT
-In order to run bitbake and build the NTRIP SWU image, you first have to build the ntrip-application recipe.***
+In order to run bitbake and build the NTRIP SWU image, you have to configure your Yocto build environment.
+***
 
-bitbake ntrip-application
+## Configuring your build environment
 
-This will create a tar.gz file in the swuupdate folder and attach it to the .swu that is sent to the device.
+You will need a build environment for the pixc4.  This is setup thru the `pixc4` branch of this fork:
+https://github.com/horiz31/yocto-ornl
 
-Please see the corresponding sections below for details.
+### Quick Start
 
-## Patches
+```
+cd $HOME
+git clone https://github.com/horiz31/yocto-ornl.git -b pixc4
+( cd yocto-ornl && make dependencies && make environment )
+```
 
-Please submit any pull requests against the `meta-ntrip` layer to https://github.com/uvdl/ntrip
+**NOTE: `make dependencies` only needs to be done once on a build machine.**
+**NOTE: by default, `make environment` will setup your Yocto environment into `$HOME/ornl-dart-yocto/build_ornl`.**
+
+You **must** follow the instructions at the end of the above environment update script.  The Yocto build system is based on many environment variables set in your current shell.  These are **NOT** portable between shells or shell windows.  Get used to calling `setup-environment` whenever (if) you start a new shell.  Or, keep a long running shell that is setup once.
 
 ## Adding the ../sources/meta-ntrip layer to your build environment
 
@@ -20,6 +31,12 @@ Please submit any pull requests against the `meta-ntrip` layer to https://github
  1. copy this (`meta-ntrip`) folder to `$YOCTO_DIR/sources/meta-ntrip`
  2. from `$YOCTO_DIR/$YOCTO_ENV`, run `bitbake-layers add-layer ../sources/meta-ntrip`
 
+### Quick Start
+
+```
+make environment-update
+```
+
 ## Building
 
 **(ensure you are in your build environment.  That means you have done setup-environment in your shell.)**
@@ -27,5 +44,25 @@ Please submit any pull requests against the `meta-ntrip` layer to https://github
  1. from `$YOCTO_DIR/$YOCTO_ENV`, run `bitbake ntrip-application`
  2. from `$YOCTO_DIR/$YOCTO_ENV`, run `bitbake ntrip-swu`
 
-Then there will be a file with a `.swu` extension built that you can upload to your device to update the software.
-You will then need to connect to a console and `make provision` in the `/usr/local/src/ntrip` folder.
+Then there will be a file with a `.swu` extension built at:
+`$YOCTO_DIR/$YOCTO_ENV/tmp/deploy/images/$MACHINE/ntrip-swu-$MACHINE-YYYYMMDDHHMMSS.swu`.  Where:
+
+```
+MACHINE=var-som-mx6-ornl
+```
+
+You can upload that file to your device to update the application and its configuration.
+
+## Configuring the application at runtime
+
+You can also change parameters of the application after it is installed.
+You will need to connect to a console and perform `make provision` in the `/usr/local/src/ntrip` folder:
+
+```
+make -C /usr/local/src/ntrip provision
+```
+
+## Patches
+
+Please submit any pull requests against the `meta-ntrip` layer to https://github.com/uvdl/ntrip
+

--- a/meta-ntrip/README.md
+++ b/meta-ntrip/README.md
@@ -2,9 +2,7 @@
 
 This file contains information on the contents of the ../sources/meta-ntrip layer.
 
-***IMPORTANT
-In order to run bitbake and build the NTRIP SWU image, you have to configure your Yocto build environment.
-***
+**IMPORTANT* In order to run bitbake and build the NTRIP SWU image, you have to configure your Yocto build environment.*
 
 ## Configuring your build environment
 


### PR DESCRIPTION
This PR is based off feature/YoctoLayerDev.  It adds default provisioning files and ensures that they are loaded into the system as part of the swupdate process.  This allows customization of the parameters, and building a .swu that implements those customizations rather than having to connect to the device and run `make -C /usr/local/src/ntrip provision` on the CLI.

It also provides the very important step of configuring the network so that the device can operate on the desired network, again with out having to log in to the USB console and fix networking parameters.